### PR TITLE
Allow cancellation of work to cause ProcessFiles to return.

### DIFF
--- a/cmd/archive_create.go
+++ b/cmd/archive_create.go
@@ -126,16 +126,21 @@ func runArchiveCreateCmd(cmd *cobra.Command, args []string) {
 		os.Exit(1)
 	}
 
-	CreateArchive(root, collection, archiveParams{
+	err:= CreateArchive(root, collection, archiveParams{
 		exclude:     allCliFlags.excludeDirs,
 		interval:    allCliFlags.sweepInterval,
 		maxProc:     allCliFlags.maxProc,
 		dryRun:      allCliFlags.dryRun,
 		deleteLocal: allCliFlags.deleteLocal,
 	})
+
+	if err != nil {
+		log.Error().Err(err).Msg("archive creation failed")
+		os.Exit(1)
+	}
 }
 
-func CreateArchive(root string, archiveRoot string, params archiveParams) {
+func CreateArchive(root string, archiveRoot string, params archiveParams) error {
 	log := logs.GetLogger()
 
 	cancelCtx, cancel := context.WithCancel(context.Background())
@@ -163,7 +168,7 @@ func CreateArchive(root string, archiveRoot string, params archiveParams) {
 			params.deleteLocal)
 	}
 
-	valet.ProcessFiles(cancelCtx, valet.ProcessParams{
+	return valet.ProcessFiles(cancelCtx, valet.ProcessParams{
 		Root:          root,
 		MatchFunc:     valet.RequiresArchiving,
 		PruneFunc:     valet.Or(userPruneFn, defaultPruneFn),

--- a/cmd/archive_create.go
+++ b/cmd/archive_create.go
@@ -154,14 +154,6 @@ func CreateArchive(root string, archiveRoot string, params archiveParams) {
 	}
 
 	clientPool := ex.NewClientPool(maxClients, time.Second*1, "--silent")
-	go func(ctx context.Context) {
-		select {
-		case <-ctx.Done():
-			log.Debug().Msg("closing the client pool")
-			clientPool.Close()
-			return
-		}
-	}(cancelCtx)
 
 	var workPlan valet.WorkPlan
 	if params.dryRun {

--- a/cmd/checksum_create.go
+++ b/cmd/checksum_create.go
@@ -104,11 +104,16 @@ func runChecksumCreateCmd(cmd *cobra.Command, args []string) {
 		os.Exit(1)
 	}
 
-	CreateChecksumFiles(root, exclude, interval, maxProc, dryRun)
+	err := CreateChecksumFiles(root, exclude, interval, maxProc, dryRun)
+
+	if err != nil {
+		log.Error().Err(err).Msg("checksum creation failed")
+		os.Exit(1)
+	}
 }
 
 func CreateChecksumFiles(root string, exclude []string, interval time.Duration,
-	maxProc int, dryRun bool) {
+	maxProc int, dryRun bool) error {
 	log := logs.GetLogger()
 
 	cancelCtx, cancel := context.WithCancel(context.Background())
@@ -128,7 +133,7 @@ func CreateChecksumFiles(root string, exclude []string, interval time.Duration,
 		workPlan = valet.CreateChecksumWorkPlan()
 	}
 
-	valet.ProcessFiles(cancelCtx, valet.ProcessParams{
+	return valet.ProcessFiles(cancelCtx, valet.ProcessParams{
 		Root:          root,
 		MatchFunc:     valet.RequiresChecksum,
 		PruneFunc:     pruneFn,

--- a/valet/pathproc.go
+++ b/valet/pathproc.go
@@ -22,12 +22,13 @@ package valet
 
 import (
 	"context"
-	"os"
 	"sync"
 	"time"
 
 	logs "github.com/kjsanger/logshim"
 	"github.com/pkg/errors"
+
+	"github.com/kjsanger/valet/utilities"
 )
 
 type token struct{}
@@ -42,7 +43,7 @@ type ProcessParams struct {
 	MaxProc       int           // The maximum number of threads to run
 }
 
-func ProcessFiles(cancelCtx context.Context, params ProcessParams) {
+func ProcessFiles(cancelCtx context.Context, params ProcessParams) error {
 
 	wpaths, werrs := WatchFiles(cancelCtx, params.Root, params.MatchFunc,
 		params.PruneFunc)
@@ -50,34 +51,33 @@ func ProcessFiles(cancelCtx context.Context, params ProcessParams) {
 		params.PruneFunc, params.SweepInterval)
 
 	mpaths := MergeFileChannels(wpaths, fpaths)
-	errs := MergeErrorChannels(werrs, ferrs)
+	merrs := MergeErrorChannels(werrs, ferrs)
 	done := make(chan token)
 
 	log := logs.GetLogger()
+	var err error
 
 	go func() {
 		defer func() { done <- token{} }()
 
-		err := DoProcessFiles(mpaths, params.Plan, params.MaxProc)
-		if err != nil {
-			log.Error().Err(err).Msg("failed processing")
-			os.Exit(1)
-		}
+		err = DoProcessFiles(mpaths, params.Plan, params.MaxProc)
 	}()
 
-	if err := <-errs; err != nil {
-		log.Error().Err(err).Msg("failed to complete processing")
-		os.Exit(1)
-	}
-
+done:
 	for {
 		select {
 		case <-done:
-			return
+			log.Info().Msg("processing done")
+			break done
 		case <-cancelCtx.Done():
-			return
+			log.Info().Msg("processing cancelled")
+			break done
 		}
 	}
+
+	merr := <-merrs
+
+	return utilities.CombineErrors(err, merr)
 }
 
 // DoProcessFiles operates by applying workPlan to each FilePath in the paths

--- a/valet/pathproc.go
+++ b/valet/pathproc.go
@@ -70,7 +70,14 @@ func ProcessFiles(cancelCtx context.Context, params ProcessParams) {
 		os.Exit(1)
 	}
 
-	<-done
+	for {
+		select {
+		case <-done:
+			return
+		case <-cancelCtx.Done():
+			return
+		}
+	}
 }
 
 // DoProcessFiles operates by applying workPlan to each FilePath in the paths


### PR DESCRIPTION
Do not close the ClientPool, so allow running work to complete.