### PR TITLE
Bugfix: handle compressed files

### DIFF
--- a/valet/predicates_test.go
+++ b/valet/predicates_test.go
@@ -102,6 +102,57 @@ func TestIsGzipFastqMatch(t *testing.T) {
 	}
 }
 
+func TestIsCompressed(t *testing.T) {
+	fq1, _ := NewFilePath("./testdata/valet/1/reads/fastq/reads1.fastq")
+	ok1, err1 := IsCompressed(fq1)
+	if assert.NoError(t, err1) {
+		assert.False(t, ok1, "expected false for a fastq file")
+	}
+
+	fq2, _ := NewFilePath("./testdata/valet/1/reads/fastq/reads2.fastq.gz")
+
+	ok2, err2 := IsCompressed(fq2)
+	if assert.NoError(t, err2) {
+		assert.True(t, ok2, "expected true for a gzipped fastq file")
+	}
+}
+
+func TestHasCompressedVersion(t *testing.T) {
+	fq1, _ := NewFilePath("./testdata/valet/1/reads/fastq/reads1.fastq")
+
+	ok1, err1 := HasCompressedVersion(fq1)
+	if assert.NoError(t, err1) {
+		assert.False(t, ok1,
+			"expected false for a fastq file without a gzipped version")
+	}
+
+	fq2, _ := NewFilePath("./testdata/valet/1/reads/fastq/reads2.fastq")
+
+	ok2, err2 := HasCompressedVersion(fq2)
+	if assert.NoError(t, err2) {
+		assert.True(t, ok2,
+			"expected true for a fastq file with a gzipped version")
+	}
+}
+
+func TestRequiresCompression(t *testing.T) {
+	fq1, _ := NewFilePath("./testdata/valet/1/reads/fastq/reads1.fastq")
+
+	ok1, err1 := RequiresCompression(fq1)
+	if assert.NoError(t, err1) {
+		assert.True(t, ok1,
+			"expected true for a fastq file without a gzipped version")
+	}
+
+	fq2, _ := NewFilePath("./testdata/valet/1/reads/fastq/reads2.fastq")
+
+	ok2, err2 := RequiresCompression(fq2)
+	if assert.NoError(t, err2) {
+		assert.False(t, ok2,
+			"expected false for a fastq file with a gzipped version")
+	}
+}
+
 func TestHasChecksumFile(t *testing.T) {
 	f5With, _ := NewFilePath("./testdata/valet/1/reads/fast5/reads1.fast5")
 	ok, err := HasChecksumFile(f5With)

--- a/valet/valet_suite_test.go
+++ b/valet/valet_suite_test.go
@@ -623,6 +623,7 @@ var _ = Describe("Archive MINKnow files", func() {
 			// Find files or timeout and cancel
 			done := make(chan bool, 2)
 
+			var perr error
 			go func() {
 				plan := valet.ArchiveFilesWorkPlan(tmpDataDir, workColl,
 					clientPool, deleteLocal)
@@ -631,7 +632,7 @@ var _ = Describe("Archive MINKnow files", func() {
 					valet.RequiresArchiving,
 					valet.RequiresCompression)
 
-				valet.ProcessFiles(cancelCtx, valet.ProcessParams{
+				perr = valet.ProcessFiles(cancelCtx, valet.ProcessParams{
 					Root:          tmpDataDir,
 					MatchFunc:     matchFn,
 					PruneFunc:     defaultPruneFn,
@@ -676,6 +677,8 @@ var _ = Describe("Archive MINKnow files", func() {
 			}()
 
 			<-done
+
+			Expect(perr).NotTo(HaveOccurred())
 
 			client, err := clientPool.Get()
 			Expect(err).NotTo(HaveOccurred())

--- a/valet/workfunc.go
+++ b/valet/workfunc.go
@@ -150,9 +150,9 @@ func ArchiveFilesWorkPlan(localBase string, remoteBase string,
 	if deleteLocal {
 		plan = append(plan,
 			WorkMatch{
-				pred: RequiresCompression,
+				pred: HasCompressedVersion,
 				work: Work{WorkFunc: RemoveFile, Rank: 4},
-				desc: "RequiresCompression => RemoveFile",
+				desc: "HasCompressedVersion => RemoveFile",
 			},
 			WorkMatch{
 				// The IsArchived test expects an MD5 file to be present and


### PR DESCRIPTION
Change RequiresCompression to assert that files must not have a
compressed version already.

Change the WorkMatch for deleting uncompressed copies to assert that
the file must simply have a compressed version.