### PR TITLE
Make the size of the client pool equal to the number of threads

### DIFF
--- a/cmd/archive_create.go
+++ b/cmd/archive_create.go
@@ -70,8 +70,6 @@ valet archive create --root /data --exclude /data/custom \
 	Run: runArchiveCreateCmd,
 }
 
-var maxClients uint8 = 12
-
 func init() {
 	archiveCreateCmd.Flags().StringVarP(&allCliFlags.localRoot,
 		"root", "r", "",
@@ -158,7 +156,8 @@ func CreateArchive(root string, archiveRoot string, params archiveParams) error 
 		os.Exit(1)
 	}
 
-	clientPool := ex.NewClientPool(maxClients, time.Second*1, "--silent")
+	clientPool := ex.NewClientPool(uint8(params.maxProc), time.Second*1,
+		"--silent")
 
 	var workPlan valet.WorkPlan
 	if params.dryRun {


### PR DESCRIPTION
As the timeout for getting clients from the pool is short, if we
control the number of iRODS connections using the pool size, we will
get an unacceptable number of failed work function calls when the
thread limit is raised.