### PR TITLE
Bugfix: missing early return in IsArchived

### DIFF
--- a/valet/predicates.go
+++ b/valet/predicates.go
@@ -355,6 +355,7 @@ func MakeIsArchived(localBase string, remoteBase string,
 				Str("expected_checksum", chk).
 				Str("checksum", obj.Checksum()).
 				Msg("not archived: checksum not confirmed")
+			return
 		}
 
 		ok, err = obj.HasValidChecksumMetadata(chk)

--- a/valet/predicates.go
+++ b/valet/predicates.go
@@ -330,12 +330,6 @@ func MakeIsArchived(localBase string, remoteBase string,
 			return
 		}
 
-		var checksum []byte
-		checksum, err = ReadMD5ChecksumFile(chkFile)
-		if err != nil {
-			return
-		}
-
 		obj := ex.NewDataObject(client, dest)
 		ok, err = obj.Exists()
 		if err != nil || !ok {
@@ -344,13 +338,16 @@ func MakeIsArchived(localBase string, remoteBase string,
 			return
 		}
 
-		chk := string(checksum)
-		ok, err = obj.HasValidChecksum(chk)
-		if err != nil {
+		var checksum []byte
+		if checksum, err = ReadMD5ChecksumFile(chkFile); err != nil {
+			log.Debug().Str("path", path.Location).
+				Msg("not archived: checksum file not readable")
 			return
 		}
 
-		if !ok {
+		chk := string(checksum)
+		ok, err = obj.HasValidChecksum(chk)
+		if err != nil || !ok {
 			log.Debug().Str("path", path.Location).
 				Str("expected_checksum", chk).
 				Str("checksum", obj.Checksum()).

--- a/valet/predicates.go
+++ b/valet/predicates.go
@@ -280,7 +280,8 @@ func IsMinKNOWRunDir(path FilePath) (bool, error) {
 }
 
 // MakeIsArchived returns a predicate that will return true if its argument has
-// been successfully archived from localBase to remoteBase.
+// been successfully archived from localBase to remoteBase and no errors occur
+// while confirming this.
 //
 // The criteria for archived state are:
 //
@@ -290,6 +291,9 @@ func IsMinKNOWRunDir(path FilePath) (bool, error) {
 // 2. The data object exists in the archive.
 //
 // 3. The checksum of the data object in the archive matches the expected
+//    checksum.
+//
+// 4. The data object has metadata under the "md5" key whose value matches the
 //    checksum.
 func MakeIsArchived(localBase string, remoteBase string,
 	cPool *ex.ClientPool) FilePredicate {
@@ -304,12 +308,12 @@ func MakeIsArchived(localBase string, remoteBase string,
 		var dest string
 		dest, err = translatePath(localBase, remoteBase, path)
 		if err != nil {
-			return
+			return false, err
 		}
 
 		client, err := cPool.Get()
 		if err != nil {
-			return
+			return false, err
 		}
 
 		defer func() {
@@ -319,30 +323,32 @@ func MakeIsArchived(localBase string, remoteBase string,
 		var chkFile FilePath
 		chkFile, err = NewFilePath(path.ChecksumFilename())
 		if err != nil {
-			return
+			return false, err
 		}
 
 		log := logs.GetLogger()
+
 		ok, err = HasValidChecksumFile(path)
 		if err != nil || !ok {
 			log.Debug().Str("path", path.Location).
 				Msg("not archived: no valid checksum file")
-			return
+			return false, err
 		}
 
 		obj := ex.NewDataObject(client, dest)
+
 		ok, err = obj.Exists()
 		if err != nil || !ok {
 			log.Debug().Str("path", path.Location).
 				Msg("not archived: data object not confirmed")
-			return
+			return false, err
 		}
 
 		var checksum []byte
 		if checksum, err = ReadMD5ChecksumFile(chkFile); err != nil {
 			log.Debug().Str("path", path.Location).
 				Msg("not archived: checksum file not readable")
-			return
+			return false, err
 		}
 
 		chk := string(checksum)
@@ -352,16 +358,16 @@ func MakeIsArchived(localBase string, remoteBase string,
 				Str("expected_checksum", chk).
 				Str("checksum", obj.Checksum()).
 				Msg("not archived: checksum not confirmed")
-			return
+			return false, err
 		}
 
 		ok, err = obj.HasValidChecksumMetadata(chk)
 		if err != nil || !ok {
 			log.Debug().Str("path", path.Location).
 				Msg("not archived: checksum metadata not confirmed")
-			return
+			return false, err
 		}
 
-		return
+		return true, err
 	}
 }


### PR DESCRIPTION
Added tests for various situations where IsArchived may return a false
result. Fixed a bug caused by a missing early return that would give a
true result even when the data object's iRODS checksum did not match the
expected checksum.