### PR TITLE
Enable an unadorned --version option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 VERSION := $(shell git describe --always --tags --dirty)
-ldflags := "-X valet/valet.Version=${VERSION}"
+ldflags := "-X github.com/kjsanger/valet/valet.Version=${VERSION}"
 build_path = "build/valet-${VERSION}"
 
 .PHONY: build coverage dist install lint test check clean

--- a/cmd/valet.go
+++ b/cmd/valet.go
@@ -89,6 +89,8 @@ func init() {
 	valetCmd.PersistentFlags().IntVarP(&allCliFlags.maxProc,
 		"max-proc", "m", defaultMaxProc,
 		"set the maximum number of processes to use")
+
+	valetCmd.SetVersionTemplate(`{{printf "%s\n" .Version}}`)
 }
 
 func runValetCmd(cmd *cobra.Command, args []string) {


### PR DESCRIPTION
Set the version template to yield only the version number and no other
text. Corrected the ldflags for the version variable.