### PR TITLE
Add primary metadata to archiving process

### DIFF
--- a/cmd/archive_create.go
+++ b/cmd/archive_create.go
@@ -179,7 +179,7 @@ func CreateArchive(root string, archiveRoot string, params archiveParams) error 
 
 	return valet.ProcessFiles(cancelCtx, valet.ProcessParams{
 		Root:          root,
-		MatchFunc:     valet.Or(valet.RequiresCompression, valet.RequiresArchiving),
+		MatchFunc:     valet.Or(valet.RequiresCompression, valet.RequiresCopying),
 		PruneFunc:     valet.Or(userPruneFn, defaultPruneFn),
 		Plan:          workPlan,
 		SweepInterval: params.interval,

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,7 @@ module github.com/kjsanger/valet
 go 1.13
 
 require (
-	github.com/kjsanger/extendo v1.1.0 // indirect
-	github.com/kjsanger/extendo/v2 v2.0.0
+	github.com/kjsanger/extendo/v2 v2.1.0
 	github.com/kjsanger/fsnotify v1.4.8-0.20190705153444-45ca73e9793a
 	github.com/kjsanger/logshim v1.1.0
 	github.com/kjsanger/logshim-zerolog v1.1.0
@@ -15,6 +14,8 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/rs/zerolog v1.18.0
 	github.com/spf13/cobra v0.0.5
-	github.com/stretchr/testify v1.4.0
+	github.com/stretchr/testify v1.5.1
 	golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4
 )
+
+// replace github.com/kjsanger/extendo/v2 => ../extendo

--- a/valet/predicates.go
+++ b/valet/predicates.go
@@ -51,6 +51,7 @@ var markdownRegex = regexp.MustCompile(fmt.Sprintf(".*[.]%s$", MarkdownSuffix))
 var pdfRegex = regexp.MustCompile(fmt.Sprintf(".*[.]%s$", PDFSuffix))
 var csvRegex = regexp.MustCompile(fmt.Sprintf(".*[.]%s$", CSVSuffix))
 var gzipRegex = regexp.MustCompile(fmt.Sprintf(".*[.]%s$", GzipSuffix))
+var reportRegex = regexp.MustCompile(fmt.Sprintf("report.*[.]%s$", MarkdownSuffix))
 
 // Matches the run ID of MinKNOW c. August 2019 for GridION and PromethION
 // i.e. of the form:
@@ -59,7 +60,7 @@ var gzipRegex = regexp.MustCompile(fmt.Sprintf(".*[.]%s$", GzipSuffix))
 //
 var MinKNOWRunIDRegex = regexp.MustCompile(`^\d+_\d+_\S+_[A-Za-z0-9]+_[A-Za-z0-9]+$`)
 
-var RequiresArchiving = Or(
+var RequiresCopying = Or(
 	IsFast5,
 	And(IsFastq, IsCompressed),
 	And(IsTxt, IsCompressed),
@@ -72,7 +73,7 @@ var RequiresArchiving = Or(
 // checksum file that is stale.
 var RequiresChecksum = And(
 	IsRegular,
-	RequiresArchiving,
+	RequiresCopying,
 	Or(Not(HasChecksumFile), HasStaleChecksumFile))
 
 var HasValidChecksumFile = Not(HasStaleChecksumFile)
@@ -81,6 +82,8 @@ var RequiresCompression = And(
 	Or(IsFastq, IsTxt),
 	Not(IsCompressed),
 	Not(HasCompressedVersion))
+
+var RequiresAnnotation = IsMinKNOWReport
 
 // IsTrue always returns true.
 func IsTrue(path FilePath) (bool, error) {
@@ -261,11 +264,18 @@ func IsMinKNOWRunDir(path FilePath) (bool, error) {
 	return IsMinKNOWRunID(filepath.Base(path.Location)), nil
 }
 
-// MakeIsArchived returns a predicate that will return true if its argument has
-// been successfully archived from localBase to remoteBase and no errors occur
+// Is IsMinKNOWReport returns true if path is a MinNKNOW run report file. This
+// file is Markdown that contains a section of JSON metadata describing details
+// of the run.
+func IsMinKNOWReport(path FilePath) (bool, error) {
+	return reportRegex.MatchString(path.Location), nil
+}
+
+// MakeIsCopied returns a predicate that will return true if its argument has
+// been successfully copied from localBase to remoteBase, and no errors occur
 // while confirming this.
 //
-// The criteria for archived state are:
+// The criteria for copied state are:
 //
 // 1. The file has a valid checksum file (not stale), otherwise there could
 //    be no way to test the checksum against the checksum in the archive.
@@ -277,13 +287,13 @@ func IsMinKNOWRunDir(path FilePath) (bool, error) {
 //
 // 4. The data object has metadata under the "md5" key whose value matches the
 //    checksum.
-func MakeIsArchived(localBase string, remoteBase string,
+func MakeIsCopied(localBase string, remoteBase string,
 	cPool *ex.ClientPool) FilePredicate {
 
 	return func(path FilePath) (ok bool, err error) { // NRV
 		defer func() {
 			if err != nil {
-				err = errors.Wrap(err, "IsArchived")
+				err = errors.Wrap(err, "IsCopied")
 			}
 		}()
 
@@ -302,59 +312,178 @@ func MakeIsArchived(localBase string, remoteBase string,
 			err = utilities.CombineErrors(err, cPool.Return(client))
 		}()
 
-		var chkFile FilePath
-		chkFile, err = NewFilePath(path.ChecksumFilename())
-		if err != nil {
-			return false, err
-		}
-
 		log := logs.GetLogger()
-
-		ok, err = HasValidChecksumFile(path)
-		if err != nil || !ok {
-			log.Debug().Str("path", path.Location).
-				Msg("not archived: no valid checksum file")
-			return false, err
-		}
-
 		obj := ex.NewDataObject(client, dest)
-
 		ok, err = obj.Exists()
 		if err != nil || !ok {
 			log.Debug().Str("path", path.Location).
-				Msg("not archived: data object not confirmed")
+				Str("to", obj.RodsPath()).
+				Msg("copy NOT confirmed")
 			return false, err
 		}
 
-		var checksum []byte
-		if checksum, err = ReadMD5ChecksumFile(chkFile); err != nil {
-			log.Debug().Str("path", path.Location).
-				Msg("not archived: checksum file not readable")
-			return false, err
-		}
-
-		chk := string(checksum)
-		ok, err = obj.HasValidChecksum(chk)
-		if err != nil || !ok {
-			log.Debug().Str("path", path.Location).
-				Str("expected_checksum", chk).
-				Str("checksum", obj.Checksum()).
-				Msg("not archived: checksum not confirmed")
-			return false, err
-		}
-
-		ok, err = obj.HasValidChecksumMetadata(chk)
-		if err != nil || !ok {
-			log.Debug().Str("path", path.Location).
-				Msg("not archived: checksum metadata not confirmed")
-			return false, err
+		ok, err = validateObjChecksum(path, obj)
+		if !ok || err != nil {
+			return ok, err
 		}
 
 		log.Debug().Str("path", path.Location).
 			Str("to", obj.RodsPath()).
 			Str("checksum", obj.Checksum()).
-			Msg("confirmed archived with correct checksum")
+			Msg("copy confirmed")
 
 		return true, err
 	}
+}
+
+// MakeIsAnnotated returns a predicate that will return true if its argument has
+// had its associated metadata annotated in iRODS, and no errors occur while
+// confirming this.
+//
+// The criteria for annotated state are:
+//
+// 1. The metadata associated with the file has been obtained e.g. parsed from
+//    a file.
+//
+// 2. The metadata are annotated in iRODS.
+//
+// Note that is not testing for the presence of a specific data object e.g. the
+// report file that contained the metadata. That is achieved using the IsCopied
+// predicate.
+func MakeIsAnnotated(localBase string, remoteBase string,
+	cPool *ex.ClientPool) FilePredicate {
+
+	return func(path FilePath) (ok bool, err error) { // NRV
+		defer func() {
+			if err != nil {
+				err = errors.Wrap(err, "IsAnnotated")
+			}
+		}()
+
+		var dest string
+		dest, err = translatePath(localBase, remoteBase, path)
+		if err != nil {
+			return false, err
+		}
+
+		var client *ex.Client
+		client, err = cPool.Get()
+		if err != nil {
+			return false, err
+		}
+
+		defer func() {
+			err = utilities.CombineErrors(err, cPool.Return(client))
+		}()
+
+		var isReport bool
+		isReport, err = IsMinKNOWReport(path)
+		if err != nil {
+			return false, err
+		}
+
+		log := logs.GetLogger()
+		if !isReport {
+			log.Debug().Str("path", path.Location).
+				Msg("not a MinKNOW report, annotation NOT confirmed")
+			return false, err
+		}
+
+		obj := ex.NewDataObject(client, dest)
+		ok, err = validateReportMetadata(path, obj)
+		if !ok || err != nil {
+			return false, err
+		}
+
+		return true, err
+	}
+}
+
+// validateObjChecksum checks that the data file at path has a corresponding
+// checksum file, that the checksum in that file is the same as that recorded
+// for the corresponding data object in iRODS, and that the data object has the
+// same checksum present in its metadata.
+func validateObjChecksum(path FilePath, obj *ex.DataObject) (bool, error) {
+	log := logs.GetLogger()
+
+	chkFile, err := NewFilePath(path.ChecksumFilename())
+	if err != nil {
+		return false, err
+	}
+
+	ok, err := HasValidChecksumFile(path)
+	if err != nil || !ok {
+		log.Debug().Str("path", path.Location).
+			Msg("valid checksum file NOT present")
+		return false, err
+	}
+
+	checksum, err := ReadMD5ChecksumFile(chkFile)
+	if err != nil {
+		log.Debug().Str("path", path.Location).
+			Msg("checksum file NOT readable")
+		return false, err
+	}
+
+	chk := string(checksum)
+	ok, err = obj.HasValidChecksum(chk)
+	if err != nil || !ok {
+		log.Debug().Str("path", path.Location).
+			Str("expected_checksum", chk).
+			Str("checksum", obj.Checksum()).
+			Msg("checksum NOT confirmed")
+		return false, err
+	}
+
+	ok, err = obj.HasValidChecksumMetadata(chk)
+	if err != nil || !ok {
+		log.Debug().Str("path", path.Location).
+			Msg("checksum metadata NOT confirmed")
+		return false, err
+	}
+
+	return true, nil
+}
+
+func validateReportMetadata(path FilePath, obj *ex.DataObject) (bool, error) {
+	log := logs.GetLogger()
+
+	report, err := ParseReport(path.Location)
+	if err != nil {
+		return false, err
+	}
+
+	// The metadata to check is on the collection containing the file in
+	// iRODS
+	coll := obj.Parent()
+	_, err = coll.FetchMetadata()
+	if err != nil {
+		return false, err
+	}
+
+	metadata := report.AsMetadata()
+	if !coll.HasAllMetadata(metadata) {
+		for _, avu := range metadata {
+			if !coll.HasMetadatum(avu) {
+				log.Debug().Str("path", coll.RodsPath()).
+					Str("attr", avu.Attr).
+					Str("value", avu.Value).Msg("missing this AVU")
+			}
+		}
+
+		log.Debug().Str("path", path.Location).
+			Str("to", coll.RodsPath()).
+			Msg("report metadata NOT confirmed")
+
+		return false, nil
+	}
+
+	for _, avu := range metadata {
+		log.Debug().Str("path", path.Location).
+			Str("attribute", avu.Attr).
+			Str("value", avu.Value).
+			Msg("report metadata confirmed")
+	}
+
+	return true, nil
 }

--- a/valet/report.go
+++ b/valet/report.go
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2020. Genome Research Ltd. All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License,
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @file report.go
+ * @author Keith James <kdj@sanger.ac.uk>
+ */
+
+package valet
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"strings"
+
+	ex "github.com/kjsanger/extendo/v2"
+	"github.com/pkg/errors"
+)
+
+const dutyTimeField = "Duty Time"
+const trackingIDField = "Tracking ID"
+
+type MinKNOWReport struct {
+	DeviceID            string `json:"device_id"`
+	DeviceType          string `json:"device_type"`
+	DistributionVersion string `json:"distribution_version"`
+	FlowcellID          string `json:"flow_cell_id"`
+	GuppyVersion        string `json:"guppy_version"`
+	Hostname            string `json:"hostname"`
+	ProtocolGroupID     string `json:"protocol_group_id"`
+	RunID               string `json:"run_id"`
+	SampleID            string `json:"sample_id"`
+}
+
+func ParseReport(path string) (MinKNOWReport, error) {
+	var report MinKNOWReport
+
+	bytes, err := ioutil.ReadFile(path)
+	if err != nil {
+		return report, err
+	}
+
+	text := string(bytes)
+	ti := strings.Index(text, trackingIDField)
+	if ti < 0 {
+		return report, errors.Errorf("failed to find %s in report file %s",
+			trackingIDField, path)
+	}
+
+	di := strings.Index(text, dutyTimeField)
+	if di < 0 {
+		return report, errors.Errorf("failed to find %s in report file %s",
+			dutyTimeField, path)
+	}
+
+	targetRegion := text[ti+len(trackingIDField) : di]
+	targetRegion = strings.ReplaceAll(targetRegion, "=", "")
+
+	if err = json.Unmarshal([]byte(targetRegion), &report); err != nil {
+		return MinKNOWReport{}, err
+	}
+
+	return report, nil
+}
+
+func (report MinKNOWReport) AsMetadata() []ex.AVU {
+	return []ex.AVU{
+		{Attr:"device_id", Value: report.DeviceID},
+		{Attr: "device_type", Value: report.DeviceType},
+		{Attr: "distribution_version", Value: report.DistributionVersion},
+		{Attr: "flowcell_id", Value: report.FlowcellID},
+		{Attr: "guppy_version", Value: report.GuppyVersion},
+		{Attr: "hostname", Value: report.Hostname},
+		{Attr: "protocol_group_id", Value: report.ProtocolGroupID},
+		{Attr: "run_id", Value: report.RunID},
+		{Attr: "sample_id", Value: report.SampleID},
+	}
+}

--- a/valet/report_test.go
+++ b/valet/report_test.go
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2020. Genome Research Ltd. All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License,
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @file report_test.go
+ * @author Keith James <kdj@sanger.ac.uk>
+ */
+
+package valet
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParsePromethIONReport(t *testing.T) {
+	path := "./testdata/valet/report_PAE48813_20200130_0940_16917585.md"
+	report, err := ParseReport(path)
+	if assert.NoError(t, err) {
+		assert.Equal(t,"2-E1-H1", report.DeviceID)
+		assert.Equal(t, "promethion", report.DeviceType)
+		assert.Equal(t, "19.12.5", report.DistributionVersion)
+		assert.Equal(t, "PAE48813", report.FlowcellID)
+		assert.Equal(t, "3.2.8+bd67289", report.GuppyVersion)
+		assert.Equal(t, "PCT0016", report.Hostname)
+		assert.Equal(t, "mMelMel3", report.ProtocolGroupID)
+		assert.Equal(t, "52a0d863bccd1d78530c425e8077150d5391fc34", report.RunID)
+		assert.Equal(t, "mMelMel3", report.SampleID)
+	}
+}
+
+func TestParseGridIONReport(t *testing.T) {
+	path := "./testdata/valet/report_ABQ808_20200204_1257_e2e93dd1.md"
+	report, err := ParseReport(path)
+	if assert.NoError(t, err) {
+		assert.Equal(t,"X2", report.DeviceID)
+		assert.Equal(t, "gridion", report.DeviceType)
+		assert.Equal(t, "19.12.2", report.DistributionVersion)
+		assert.Equal(t, "ABQ808", report.FlowcellID)
+		assert.Equal(t, "3.2.8+bd67289", report.GuppyVersion)
+		assert.Equal(t, "GXB02004", report.Hostname)
+		assert.Equal(t, "85", report.ProtocolGroupID)
+		assert.Equal(t, "5531cbcf622d2d98dbff00af0261c6f19f91340f", report.RunID)
+		assert.Equal(t, "DN615089W_B1", report.SampleID)
+	}
+}

--- a/valet/testdata/platform/ont/minknow/gridion/66/DN585561I_A1/20190904_1514_GA20000_FAL01979_43578c8f/report.md
+++ b/valet/testdata/platform/ont/minknow/gridion/66/DN585561I_A1/20190904_1514_GA20000_FAL01979_43578c8f/report.md
@@ -1,1 +1,50 @@
-c6559529-02a4-4227-b066-2f1d8d193631
+Tracking ID
+===========
+
+{
+    "asic_id": "485154670",
+    "asic_id_eeprom": "5171105",
+    "asic_temp": "32.186131",
+    "asic_version": "IA02D",
+    "auto_update": "0",
+    "auto_update_source": "https://mirror.oxfordnanoportal.com/software/MinKNOW/",
+    "bream_is_standard": "0",
+    "device_id": "GA20000",
+    "device_type": "gridion",
+    "distribution_status": "stable",
+    "distribution_version": "19.06.9",
+    "exp_script_name": "N/A",
+    "exp_script_purpose": "sequencing_run",
+    "exp_start_time": "2019-09-04T15:17:19Z",
+    "flow_cell_id": "FAL01979",
+    "guppy_version": "3.0.6+9999d81",
+    "heatsink_temp": "33.957031",
+    "hostname": "GXB02004",
+    "installation_type": "nc",
+    "local_firmware_file": "1",
+    "operating_system": "ubuntu 16.04",
+    "protocol_group_id": "66",
+    "protocol_run_id": "",
+    "protocols_version": "4.1.9",
+    "run_id": "9cd2a77baacfe99d6b16f3dad2c36ecf5a6283c3",
+    "sample_id": "DN585561I_A1",
+    "usb_config": "GridX5_fx3_1.1.3_ONT#MinION_fpga_1.1.1#ctrl#Auto",
+    "version": "3.4.8"
+}
+
+Duty Time
+=========
+
+ID: 9cd2a77baacfe99d6b16f3dad2c36ecf5a6283c3
+
+Channel State,Experiment Time (minutes),State Time (samples),
+strand,0,30126393
+strand,1,47056953
+strand,2,101149137
+strand,3,101125600
+strand,4,101173418
+strand,5,100614946
+strand,6,101259488
+strand,7,101515274
+strand,8,101592777
+strand,9,101687148

--- a/valet/testdata/platform/ont/minknow/promethion/DN467851H_Multiplex_Pool_1/DN467851H_B2_C2_E2_F2/20190820_1538_2-E7-H7_PAD71219_a4a384ec/report.md
+++ b/valet/testdata/platform/ont/minknow/promethion/DN467851H_Multiplex_Pool_1/DN467851H_B2_C2_E2_F2/20190820_1538_2-E7-H7_PAD71219_a4a384ec/report.md
@@ -1,1 +1,50 @@
-237f2388-00bd-414f-af50-1ca72bf4a387
+Tracking ID
+===========
+
+{
+    "asic_id": "0004A30B00271C26",
+    "asic_id_eeprom": "0004A30B00271C26",
+    "asic_temp": "30.315973",
+    "asic_version": "Unknown",
+    "auto_update": "0",
+    "auto_update_source": "https://mirror.oxfordnanoportal.com/software/MinKNOW/",
+    "bream_is_standard": "0",
+    "device_id": "2-E7-H7",
+    "device_type": "promethion",
+    "distribution_status": "stable",
+    "distribution_version": "19.06.9",
+    "exp_script_name": "N/A",
+    "exp_script_purpose": "sequencing_run",
+    "exp_start_time": "2019-08-20T15:40:18Z",
+    "flow_cell_id": "PAD71219",
+    "guppy_version": "3.0.5+45c3543",
+    "heatsink_temp": "36.303722",
+    "hostname": "PCT0016",
+    "hublett_board_id": "0138a8860239bcc1",
+    "hublett_firmware_version": "2.0.12",
+    "installation_type": "nc",
+    "ip_address": "",
+    "local_firmware_file": "1",
+    "mac_address": "",
+    "operating_system": "ubuntu 16.04",
+    "protocol_group_id": "DN467851H_Multiplex_Pool_1",
+    "protocol_run_id": "",
+    "protocols_version": "4.1.8",
+    "run_id": "5a61cd0f2001c43c7aaf1f084ff61103267c0c33",
+    "sample_id": "DN467851H_B2_C2_E2_F2",
+    "satellite_board_id": "0000000000000000",
+    "satellite_firmware_version": "2.0.12",
+    "usb_config": "firm_1.2.3_ware#rbt_4.5.6_rbt#ctrl#USB3",
+    "version": "3.4.6"
+}
+
+Duty Time
+=========
+
+ID: 5a61cd0f2001c43c7aaf1f084ff61103267c0c33
+
+Channel State,Experiment Time (minutes),State Time (samples),
+strand,0,183372819
+strand,1,174467713
+strand,2,338669372
+strand,3,453221196

--- a/valet/testdata/platform/ont/minknow/promethion/DN467851H_Multiplex_Pool_2/DN467851H_A3_F3_G3_H3/20190821_1545_1-A1-D1_PAD73195_440ab859/report.md
+++ b/valet/testdata/platform/ont/minknow/promethion/DN467851H_Multiplex_Pool_2/DN467851H_A3_F3_G3_H3/20190821_1545_1-A1-D1_PAD73195_440ab859/report.md
@@ -1,1 +1,50 @@
-54a4a7d6-3d95-40a2-b3fe-ed8f1487b8c4
+Tracking ID
+===========
+
+{
+    "asic_id": "0004A30B00259368",
+    "asic_id_eeprom": "0004A30B00259368",
+    "asic_temp": "31.289753",
+    "asic_version": "Unknown",
+    "auto_update": "0",
+    "auto_update_source": "https://mirror.oxfordnanoportal.com/software/MinKNOW/",
+    "bream_is_standard": "0",
+    "device_id": "1-A1-D1",
+    "device_type": "promethion",
+    "distribution_status": "stable",
+    "distribution_version": "19.06.9",
+    "exp_script_name": "N/A",
+    "exp_script_purpose": "sequencing_run",
+    "exp_start_time": "2019-08-21T15:46:15Z",
+    "flow_cell_id": "PAD73195",
+    "guppy_version": "3.0.5+45c3543",
+    "heatsink_temp": "35.561672",
+    "hostname": "PCT0016",
+    "hublett_board_id": "013bec8739c4bd8a",
+    "hublett_firmware_version": "2.0.12",
+    "installation_type": "nc",
+    "ip_address": "",
+    "local_firmware_file": "1",
+    "mac_address": "",
+    "operating_system": "ubuntu 16.04",
+    "protocol_group_id": "DN467851H_Multiplex_Pool_2",
+    "protocol_run_id": "",
+    "protocols_version": "4.1.8",
+    "run_id": "86b15e57ca99113b4bb75b4ad1e8da937dde06d9",
+    "sample_id": "DN467851H_A3_F3_G3_H3",
+    "satellite_board_id": "0000000000000000",
+    "satellite_firmware_version": "2.0.12",
+    "usb_config": "firm_1.2.3_ware#rbt_4.5.6_rbt#ctrl#USB3",
+    "version": "3.4.6"
+}
+
+Duty Time
+=========
+
+ID: 86b15e57ca99113b4bb75b4ad1e8da937dde06d9
+
+Channel State,Experiment Time (minutes),State Time (samples),
+strand,0,72497251
+strand,1,71526559
+strand,2,147421963
+strand,3,221293829

--- a/valet/testdata/valet/report_ABQ808_20200204_1257_e2e93dd1.md
+++ b/valet/testdata/valet/report_ABQ808_20200204_1257_e2e93dd1.md
@@ -1,0 +1,53 @@
+Tracking ID
+===========
+
+{
+    "asic_id": "348039508",
+    "asic_id_eeprom": "5881658",
+    "asic_temp": "33.569710",
+    "asic_version": "IA02D",
+    "auto_update": "0",
+    "auto_update_source": "https://mirror.oxfordnanoportal.com/software/MinKNOW/",
+    "bream_is_standard": "0",
+    "configuration_version": "1.0.1",
+    "device_id": "X2",
+    "device_type": "gridion",
+    "distribution_status": "stable",
+    "distribution_version": "19.12.2",
+    "exp_script_name": "N/A",
+    "exp_script_purpose": "sequencing_run",
+    "exp_start_time": "2020-02-04T12:57:07Z",
+    "flongle_adapter_id": "FA-01176",
+    "flow_cell_id": "ABQ808",
+    "flow_cell_product_code": "FLO-FLG001",
+    "guppy_version": "3.2.8+bd67289",
+    "heatsink_temp": "32.878906",
+    "hostname": "GXB02004",
+    "installation_type": "nc",
+    "local_firmware_file": "1",
+    "operating_system": "ubuntu 16.04",
+    "protocol_group_id": "85",
+    "protocol_run_id": "",
+    "protocols_version": "4.3.12",
+    "run_id": "5531cbcf622d2d98dbff00af0261c6f19f91340f",
+    "sample_id": "DN615089W_B1",
+    "usb_config": "GridX5_fx3_1.1.3_ONT#MinION_fpga_1.1.1#bulk#Auto",
+    "version": "3.6.0"
+}
+
+Duty Time
+=========
+
+ID: 5531cbcf622d2d98dbff00af0261c6f19f91340f
+
+Channel State,Experiment Time (minutes),State Time (samples),
+strand,0,247335
+strand,1,2414751
+strand,2,6560659
+strand,3,6237473
+strand,4,4193670
+strand,5,5053742
+strand,6,5342936
+strand,7,5553357
+strand,8,5252650
+strand,9,5527674

--- a/valet/testdata/valet/report_PAE48813_20200130_0940_16917585.md
+++ b/valet/testdata/valet/report_PAE48813_20200130_0940_16917585.md
@@ -1,0 +1,58 @@
+Tracking ID
+===========
+
+{
+    "asic_id": "0004A30B00F02E5B",
+    "asic_id_eeprom": "0004A30B00F02E5B",
+    "asic_temp": "32.309902",
+    "asic_version": "Unknown",
+    "auto_update": "0",
+    "auto_update_source": "https://mirror.oxfordnanoportal.com/software/MinKNOW/",
+    "bream_is_standard": "0",
+    "configuration_version": "1.0.7",
+    "device_id": "2-E1-H1",
+    "device_type": "promethion",
+    "distribution_status": "stable",
+    "distribution_version": "19.12.5",
+    "exp_script_name": "N/A",
+    "exp_script_purpose": "sequencing_run",
+    "exp_start_time": "2020-01-30T09:40:16Z",
+    "flow_cell_id": "PAE48813",
+    "flow_cell_product_code": "FLO-PRO002",
+    "guppy_version": "3.2.8+bd67289",
+    "heatsink_temp": "35.931011",
+    "hostname": "PCT0016",
+    "hublett_board_id": "0135bb25a712a5a6",
+    "hublett_firmware_version": "2.0.14",
+    "installation_type": "nc",
+    "ip_address": "",
+    "local_firmware_file": "1",
+    "mac_address": "",
+    "operating_system": "ubuntu 16.04",
+    "protocol_group_id": "mMelMel3",
+    "protocol_run_id": "",
+    "protocols_version": "4.3.16",
+    "run_id": "52a0d863bccd1d78530c425e8077150d5391fc34",
+    "sample_id": "mMelMel3",
+    "satellite_board_id": "0000000000000000",
+    "satellite_firmware_version": "2.0.14",
+    "usb_config": "firm_1.2.3_ware#rbt_4.5.6_rbt#ctrl#USB3",
+    "version": "3.6.1"
+}
+
+Duty Time
+=========
+
+ID: 52a0d863bccd1d78530c425e8077150d5391fc34
+
+Channel State,Experiment Time (minutes),State Time (samples),
+strand,0,44514264
+strand,1,42101815
+strand,2,106669707
+strand,3,272510152
+strand,4,302900211
+strand,5,304071449
+strand,6,310356365
+strand,7,317878739
+strand,8,318033602
+strand,9,326785323

--- a/valet/workfunc.go
+++ b/valet/workfunc.go
@@ -561,7 +561,7 @@ func MakeAnnotator(localBase string, remoteBase string,
 			}
 
 			obj := ex.NewDataObject(client, dst)
-			err = obj.Parent().AddMetadata(report.AsMetadata())
+			err = obj.Parent().ReplaceMetadata(report.AsMetadata())
 			if err != nil {
 				return
 			}


### PR DESCRIPTION
MinKNOW produces a Markdown file named `report.md` or `report_*.md` which
contains useful information that we want to add to iRODS metadata. The
metadata applies to the whole run e.g. flowcell, device, run ID,
sample name.

- Add a parser and tests for examples of report files from both GridION
  and PromethION.

- Redefine archiving as two components; copying and annotation.

  Copying consists of checksumming, copying and checksum confirmation.

  Annotation consists of parsing the report file, adding the metadata
  to the collection that contains the report file in iRODS (not to the
  report data object itself) and checking the metadata.

- The report file is not deemed archived until the metadata are
  present in iRODS.

Requires extendo v2.1.0