### PR TITLE
Add "ont" namespace to iRODS metadata attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - [![Build Status](https://travis-ci.org/kjsanger/valet.svg?branch=devel)](https://travis-ci.org/kjsanger/valet)
 
+
+### Added
+
+- Add "ont" namespace to iRODS metadata attributes.
+
+### Changed
+
+- Bump github.com/kjsanger/extendo from 2.1.0 to 2.2.0
+
 ## [1.3.0] - 2020-06-02
 
 ### Added
@@ -14,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Bump github.com/kjsanger/extendo from 2.0.0 to 2.1.0
 - Bump github.com/stretchr/testify from 1.5.1 to 1.6.0
 - Bump github.com/onsi/ginkgo from 1.12.0 to 1.12.2
 
@@ -22,13 +32,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - A systemd unit template and wrapper script.
-- A String() method for WorkPlan.
+- A String method to WorkPlan.
 - Logging immediately before and after a work function is called.
 
 ### Changed
 
-- Improved verbose level logging for consistency and information.
-- Added to default paths to ignore in the data root.
+- Improve verbose level logging for consistency and information.
+- Add to default paths to ignore in the data root.
 
 - Bump github.com/kjsanger/extendo from 1.1.0 to 2.0.0
 - Bump github.com/onsi/ginkgo from 1.10.3 to 1.12.0

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/kjsanger/valet
 go 1.13
 
 require (
-	github.com/kjsanger/extendo/v2 v2.1.0
+	github.com/kjsanger/extendo/v2 v2.2.0
 	github.com/kjsanger/fsnotify v1.4.8-0.20190705153444-45ca73e9793a
 	github.com/kjsanger/logshim v1.1.0
 	github.com/kjsanger/logshim-zerolog v1.1.0

--- a/valet/report.go
+++ b/valet/report.go
@@ -84,7 +84,7 @@ func ParseMinKNOWReport(path string) (MinKNOWReport, error) {
 
 // AsMetadata returns the report content as iRODS AVUs.
 func (report MinKNOWReport) AsMetadata() []ex.AVU {
-	return []ex.AVU{
+	avus := []ex.AVU{
 		{Attr: "device_id", Value: report.DeviceID},
 		{Attr: "device_type", Value: report.DeviceType},
 		{Attr: "distribution_version", Value: report.DistributionVersion},
@@ -95,6 +95,12 @@ func (report MinKNOWReport) AsMetadata() []ex.AVU {
 		{Attr: "run_id", Value: report.RunID},
 		{Attr: "sample_id", Value: report.SampleID},
 	}
+
+	for i := range avus {
+		avus[i] = avus[i].WithNamespace(OxfordNanoporeNamespace)
+	}
+
+	return avus
 }
 
 // AsEnhancedMetadata returns the report as iRODS AVUs. It returns all the AVUs
@@ -117,8 +123,13 @@ func (report MinKNOWReport) AsEnhancedMetadata() ([]ex.AVU, error) {
 		return avus, errors.Errorf("Failed to parse device ID '%s'", deviceID)
 	}
 
-	avus = append(avus, ex.MakeAVU("instrument_slot", idMatch[1]))
-	avus = append(avus, ex.MakeAVU("experiment_name", report.ProtocolGroupID))
+	slot := ex.AVU{Attr:"instrument_slot", Value: idMatch[1]}.
+		WithNamespace(OxfordNanoporeNamespace)
+	expt := ex.AVU{Attr:"experiment_name", Value: report.ProtocolGroupID}.
+		WithNamespace(OxfordNanoporeNamespace)
+
+	avus = append(avus, slot)
+	avus = append(avus, expt)
 
 	return avus, nil
 }

--- a/valet/valet_suite_test.go
+++ b/valet/valet_suite_test.go
@@ -761,17 +761,17 @@ var _ = Describe("IsAnnotated", func() {
 		// on the collection containing the report data object, not on the data
 		// object itself.
 		err = coll.AddMetadata([]ex.AVU{
-			{Attr: "device_id", Value: "X2"},
-			{Attr: "device_type", Value: "gridion"},
-			{Attr: "distribution_version", Value: "19.12.2"},
-			{Attr: "experiment_name", Value: "85"},
-			{Attr: "flowcell_id", Value: "ABQ808"},
-			{Attr: "guppy_version", Value: "3.2.8+bd67289"},
-			{Attr: "hostname", Value: "GXB02004"},
-			{Attr: "instrument_slot", Value: "2"},
-			{Attr: "protocol_group_id", Value: "85"},
-			{Attr: "run_id", Value: "5531cbcf622d2d98dbff00af0261c6f19f91340f"},
-			{Attr: "sample_id", Value: "DN615089W_B1"},
+			{Attr: "ont:device_id", Value: "X2"},
+			{Attr: "ont:device_type", Value: "gridion"},
+			{Attr: "ont:distribution_version", Value: "19.12.2"},
+			{Attr: "ont:experiment_name", Value: "85"},
+			{Attr: "ont:flowcell_id", Value: "ABQ808"},
+			{Attr: "ont:guppy_version", Value: "3.2.8+bd67289"},
+			{Attr: "ont:hostname", Value: "GXB02004"},
+			{Attr: "ont:instrument_slot", Value: "2"},
+			{Attr: "ont:protocol_group_id", Value: "85"},
+			{Attr: "ont:run_id", Value: "5531cbcf622d2d98dbff00af0261c6f19f91340f"},
+			{Attr: "ont:sample_id", Value: "DN615089W_B1"},
 		})
 		Expect(err).NotTo(HaveOccurred())
 
@@ -811,7 +811,7 @@ var _ = Describe("IsAnnotated", func() {
 	When("a metadata AVU is missing", func() {
 		BeforeEach(func() {
 			err := coll.RemoveMetadata([]ex.AVU{{
-				Attr:  "device_id",
+				Attr:  "ont:device_id",
 				Value: "X2"}})
 			Expect(err).NotTo(HaveOccurred())
 		})
@@ -823,10 +823,10 @@ var _ = Describe("IsAnnotated", func() {
 
 	When("a metadata AVU is mismatched", func() {
 		BeforeEach(func() {
-			err := coll.RemoveMetadata([]ex.AVU{{Attr: "device_id", Value: "X2"}})
+			err := coll.RemoveMetadata([]ex.AVU{{Attr: "ont:device_id", Value: "X2"}})
 			Expect(err).NotTo(HaveOccurred())
 
-			err = coll.AddMetadata([]ex.AVU{{Attr: "device_id", Value: "X5"}})
+			err = coll.AddMetadata([]ex.AVU{{Attr: "ont:device_id", Value: "X5"}})
 			Expect(err).NotTo(HaveOccurred())
 		})
 

--- a/valet/workfunc.go
+++ b/valet/workfunc.go
@@ -81,6 +81,8 @@ type WorkMatch struct {
 	workDoc string        // A short description of the work
 }
 
+const OxfordNanoporeNamespace string = "ont"
+
 // String returns a descriptive string for the WorkMatch which includes the
 // predicate and work documentation strings.
 func (m WorkMatch) String() string {


### PR DESCRIPTION
Add a namespace to prevent overlap with metadata attributes from other
platforms in iRODS. Requires namespace methods added in extendo 2.2.0