### PR TITLE
Remove iRODS 4.1.12 and add iRODS 4.2.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,13 +9,22 @@ go:
   - "1.13"
   - "1.14"
 
+_iRODS_4_2_8: &iRODS_4_2_8 DOCKER_IMAGE="wsinpg/ub-18.04-irods-4.2.8:latest" IRODS_VERSION="==4.2.8" BATON_VERSION=">2.0.1"
+
 env:
   global:
     - GO111MODULE=on
     - WSI_CONDA_CHANNEL="https://dnap.cog.sanger.ac.uk/npg/conda/devel/generic"
-  matrix:
-    - DOCKER_IMAGE="wsinpg/ub-12.04-irods-4.1:latest" IRODS_VERSION="==4.1.12" BATON_VERSION="==2.0.1"
+  jobs:
     - DOCKER_IMAGE="wsinpg/ub-16.04-irods-4.2.7:latest" IRODS_VERSION="==4.2.7" BATON_VERSION=">2.0.1"
+    - *iRODS_4_2_8
+
+jobs:
+  allow_failures:
+    - go: "1.13"
+      env: *iRODS_4_2_8
+    - go: "1.14"
+      env: *iRODS_4_2_8
 
 cache:
   directories:

--- a/scripts/travis_install.sh
+++ b/scripts/travis_install.sh
@@ -22,21 +22,7 @@ conda install -y baton"$BATON_VERSION"
 
 mkdir -p ~/.irods
 
-if [[ "$IRODS_VERSION" =~ 4\.1\.12 ]]
-then
-    cat <<EOF > ~/.irods/irods_environment.json
-{
-    "irods_host": "localhost",
-    "irods_port": 1247,
-    "irods_user_name": "irods",
-    "irods_zone_name": "testZone",
-    "irods_home": "/testZone/home/irods",
-    "irods_plugins_home": "$HOME/miniconda/envs/travis/lib/irods/plugins/",
-    "irods_default_resource": "testResc"
-}
-EOF
-else
-    cat <<'EOF' > ~/.irods/irods_environment.json
+cat <<'EOF' > ~/.irods/irods_environment.json
 {
     "irods_host": "localhost",
     "irods_port": 1247,
@@ -46,7 +32,6 @@ else
     "irods_default_resource": "testResc"
 }
 EOF
-fi
 
 go get github.com/onsi/ginkgo/ginkgo
 go get github.com/onsi/gomega/...


### PR DESCRIPTION
iRODS 4.2.8 is marked as an expected failure because we have not yet
built a Conda package of irods-icommands for iRODS 4.2.8